### PR TITLE
Add Apple MPS device support

### DIFF
--- a/inference_objectclear.py
+++ b/inference_objectclear.py
@@ -10,7 +10,12 @@ import numpy as np
 
 
 if __name__ == '__main__':
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    if torch.cuda.is_available():
+        device = torch.device('cuda')
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    else:
+        device = torch.device('cpu')
     parser = argparse.ArgumentParser()
 
     parser.add_argument('-i', '--input_path', type=str, default='./inputs/imgs', 
@@ -63,7 +68,7 @@ if __name__ == '__main__':
     # ------------------ set up ObjectClear pipeline -------------------
     torch_dtype = torch.float16 if args.use_fp16 else torch.float32
     variant = "fp16" if args.use_fp16 else None
-    generator = torch.Generator(device=device).manual_seed(args.seed)
+    generator = torch.Generator(device='cpu').manual_seed(args.seed)
     use_agf = not args.no_agf
     pipe = ObjectClearPipeline.from_pretrained_with_custom_modules(
         "jixin0101/ObjectClear",


### PR DESCRIPTION
## Summary
- Add MPS (Metal Performance Shaders) device detection for inference on Apple Silicon Macs, with fallback order: CUDA > MPS > CPU
- Use CPU-based `torch.Generator` to ensure deterministic outputs across all devices (CUDA, MPS, CPU) for a given seed

## Details

The pipeline already works on MPS out of the box since it's built on diffusers. The only missing piece was the device selection in `inference_objectclear.py`.

The generator change ensures reproducibility: `torch.Generator(device='cpu')` produces identical random sequences regardless of the compute device, which is the [recommended practice](https://huggingface.co/docs/diffusers/using-diffusers/reproducibility) in diffusers.

Tested on Apple M-series with PyTorch 2.10 and diffusers 0.37 — ~5x speedup over CPU.

## Test plan
- [x] Verified MPS inference produces valid outputs
- [x] Verified reproducibility: identical hashes across two runs with same seed on MPS
- [x] Verified CPU generator produces identical latent sequences on both CPU and MPS
- [x] Verified all key ops on MPS: `scaled_dot_product_attention`, `Conv2d`, `GroupNorm`, `randn_tensor`
- [x] No NaN or Inf in any intermediate tensors